### PR TITLE
Add source vs test path option, source extension option, and elixir language

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Have a problem or idea? Make an [issue](https://github.com/herisetiawan00/jtt.nv
 ---
 
 ## Table of Contents
+
 1. [Features](#features)
 2. [Requirements](#requirements)
 3. [Installation](#installation)
 4. [Configurations](#configurations)
 5. [Options](#options)
-6. [Usage](#usage) 
+6. [Usage](#usage)
 
 ## Features
 
@@ -43,28 +44,41 @@ Use your favorite plugin manager :)
 
 You can pass custom pattern into `setup({ ... })`.
 Examples:
+
 ```lua
   require("jtt").setup({
     languages = {
       dart = { mode = "suffix", test = "_test", ext = ".dart" },
       python = { mode = "prefix", test = "test_", ext = ".py" },
       typescript = { mode = "suffix", test = ".spec", ext = ".ts" },
+      elixir = {
+        mode = "suffix",
+        test = "_test",
+        ext = ".exs",
+        source_ext = ".ex",
+        source_path_prefix = "lib",
+        test_path_prefix = "test"
+      }
     }
   })
 ```
 
 ## Options
 
-| Option Name              | Type                         | Default Value                                                                                            | Required (Y/N) | Meaning                                      |
-| ------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------- |
-| languages                | [Table](#languages-options)  | [See Config](https://github.com/herisetiawan00/jtt.nvim/blob/main/lua/jtt/config/language_defaults.lua)  | Y              |List of pattern for each languages           |
+| Option Name | Type                        | Default Value                                                                                           | Required (Y/N) | Meaning                            |
+| ----------- | --------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------- |
+| languages   | [Table](#languages-options) | [See Config](https://github.com/herisetiawan00/jtt.nvim/blob/main/lua/jtt/config/language_defaults.lua) | Y              | List of pattern for each languages |
 
 ### Languages Options
-| Option name |  Type                                     |  Default Value          | Required (Y/N) | Meaning                                                                                | Example          |
-| ----------- | ----------------------------------------- |  ---------------------- | -------------- | -------------------------------------------------------------------------------------- | ---------------- |
-| mode        | String (`prefix`, `suffix`)               |                         | Y              | Mode is required to know how the file name structured and where is test identifier are | `prefix`         | 
-| test        | String                                    |                         | Y              | Test file name identifier pattern                                                      | `test_`, `.spec` |
-| ext         | String                                    | Current buffer file ext | N              | Filter for file extension to find                                                      | `.dart`, `.rs`   |
+
+| Option name        | Type                        | Default Value           | Required (Y/N) | Meaning                                                                                                                                                                                                                                                                                                                                                                                                  | Example                |
+| ------------------ | --------------------------- | ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| mode               | String (`prefix`, `suffix`) |                         | Y              | Mode is required to know how the file name structured and where is test identifier are                                                                                                                                                                                                                                                                                                                   | `prefix`               |
+| test               | String                      |                         | Y              | Test file name identifier pattern                                                                                                                                                                                                                                                                                                                                                                        | `test_`, `.spec`       |
+| ext                | String                      | Current buffer file ext | N              | Filter for file extension to find                                                                                                                                                                                                                                                                                                                                                                        | `.dart`, `.rs`, `.exs` |
+| source_ext         | String                      | Value of `ext` option   | N              | File extension for source files if it differs from test files                                                                                                                                                                                                                                                                                                                                            | `.ex`                  |
+| source_path_prefix | String                      | nil                     | N              | Path prefix for where source files are stored. This option should be used if the source file structure mirrors the test file structure (e.g. `app/models/user.rb` and `spec/models/user_spec.rb`) and you are working in a project with duplicate file names (e.g. `app/views/users/show.html.erb` and `app/views/posts/show.html.erb`). Usage requires `test_path_prefix` option to be defined as well. | `app`                  |
+| test_path_prefix   | String                      | nil                     | N              | Path prefix for where test files are stored. Usage requires `source_path_prefix` option to be defined as well.                                                                                                                                                                                                                                                                                           | `spec`                 |
 
 ## Usage
 

--- a/lua/jtt/config/language_defaults.lua
+++ b/lua/jtt/config/language_defaults.lua
@@ -1,5 +1,6 @@
 return {
 	dart = require("jtt.languages.dart"),
+	elixir = require("jtt.languages.elixir"),
 	go = require("jtt.languages.go"),
 	java = require("jtt.languages.java"),
 	javascript = require("jtt.languages.javascript"),

--- a/lua/jtt/init.lua
+++ b/lua/jtt/init.lua
@@ -40,7 +40,7 @@ function M.jump_to_test()
 		return
 	end
 
-	local result = vim.fn.system("fd " .. target_file .. " .")
+	local result = vim.fn.system("fd --full-path " .. target_file)
 	local path = trim(result:match("([^\n]*)"))
 
 	if path ~= "" then

--- a/lua/jtt/init.lua
+++ b/lua/jtt/init.lua
@@ -40,7 +40,9 @@ function M.jump_to_test()
 		return
 	end
 
-	local result = vim.fn.system("fd --full-path " .. target_file)
+	local search_path = handler:get_path()
+
+	local result = vim.fn.system("fd -g " .. target_file .. " " .. search_path)
 	local path = trim(result:match("([^\n]*)"))
 
 	if path ~= "" then

--- a/lua/jtt/languages/base.lua
+++ b/lua/jtt/languages/base.lua
@@ -22,17 +22,6 @@ end
 
 function Language:get_target()
 	local basename = vim.fn.expand("%:t:r")
-	local path_head = vim.fn.expand("%:h")
-
-	local source_path_prefix = self:get_opt("source_path_prefix")
-	local test_path_prefix = self:get_opt("test_path_prefix")
-
-	local source_path_head = ""
-	local test_path_head = ""
-	if source_path_prefix and test_path_prefix then
-		source_path_head = string.gsub(path_head, test_path_prefix, source_path_prefix, 1)
-		test_path_head = string.gsub(path_head, source_path_prefix, test_path_prefix, 1)
-	end
 
 	local ext = self:get_opt("ext")
 	if ext == nil then
@@ -46,18 +35,38 @@ function Language:get_target()
 
 	if mode == "prefix" then
 		if basename:sub(1, #test) == test then
-			return source_path_head .. "/" .. basename:sub(#test + 1) .. source_ext
+			return basename:sub(#test + 1) .. source_ext
 		else
-			return test_path_head .. "/" .. test .. basename .. ext
+			return test .. basename .. ext
 		end
 	elseif mode == "suffix" then
 		if basename:sub(-#test) == test then
-			return source_path_head .. "/" .. basename:sub(1, #basename - #test) .. source_ext
+			return basename:sub(1, #basename - #test) .. source_ext
 		else
-			return test_path_head .. "/" .. basename .. test .. ext
+			return basename .. test .. ext
 		end
 	else
 		error("Unknown mode: " .. tostring(mode))
+	end
+end
+
+function Language:get_path()
+	local basename = vim.fn.expand("%:t:r")
+	local path_head = vim.fn.expand("%:h")
+
+	local source_path_prefix = self:get_opt("source_path_prefix")
+	local test_path_prefix = self:get_opt("test_path_prefix")
+
+	if not source_path_prefix or not test_path_prefix then
+		return "."
+	end
+
+	local test = self:get_opt("test") or ""
+
+	if basename:sub(1, #test) == test or basename:sub(-#test) == test then
+		return string.gsub(path_head, test_path_prefix, source_path_prefix, 1)
+	else
+		return string.gsub(path_head, source_path_prefix, test_path_prefix, 1)
 	end
 end
 

--- a/lua/jtt/languages/base.lua
+++ b/lua/jtt/languages/base.lua
@@ -22,25 +22,39 @@ end
 
 function Language:get_target()
 	local basename = vim.fn.expand("%:t:r")
+	local path_head = vim.fn.expand("%:h")
+
+	local source_path_prefix = self:get_opt("source_path_prefix")
+	local test_path_prefix = self:get_opt("test_path_prefix")
+
+	local source_path_head = ""
+	local test_path_head = ""
+	if source_path_prefix and test_path_prefix then
+		source_path_head = string.gsub(path_head, test_path_prefix, source_path_prefix, 1)
+		test_path_head = string.gsub(path_head, source_path_prefix, test_path_prefix, 1)
+	end
+
 	local ext = self:get_opt("ext")
 	if ext == nil then
 		ext = "." .. vim.fn.expand("%:e")
 	end
+
+	local source_ext = self:get_opt("source_ext") or ext
 
 	local mode = self:get_opt("mode")
 	local test = self:get_opt("test") or ""
 
 	if mode == "prefix" then
 		if basename:sub(1, #test) == test then
-			return basename:sub(#test + 1) .. ext
+			return source_path_head .. "/" .. basename:sub(#test + 1) .. source_ext
 		else
-			return test .. basename .. ext
+			return test_path_head .. "/" .. test .. basename .. ext
 		end
 	elseif mode == "suffix" then
-		if basename:sub(- #test) == test then
-			return basename:sub(1, #basename - #test) .. ext
+		if basename:sub(-#test) == test then
+			return source_path_head .. "/" .. basename:sub(1, #basename - #test) .. source_ext
 		else
-			return basename .. test .. ext
+			return test_path_head .. "/" .. basename .. test .. ext
 		end
 	else
 		error("Unknown mode: " .. tostring(mode))

--- a/lua/jtt/languages/elixir.lua
+++ b/lua/jtt/languages/elixir.lua
@@ -3,6 +3,6 @@ return {
 	test = "_test",
 	ext = ".exs",
 	source_ext = ".ex",
-	source_path_prefix = "lib/",
-	test_path_prefix = "test/",
+	source_path_prefix = "lib",
+	test_path_prefix = "test",
 }

--- a/lua/jtt/languages/elixir.lua
+++ b/lua/jtt/languages/elixir.lua
@@ -1,0 +1,8 @@
+return {
+	mode = "suffix",
+	test = "_test",
+	ext = ".exs",
+	source_ext = ".ex",
+	source_path_prefix = "lib/",
+	test_path_prefix = "test/",
+}


### PR DESCRIPTION
# Context

Currently test/source files are searched for only by name. This can be a problem for projects that have multiple files with the same name but different path (e.g. multiple `index.html.erb` files in a rails app), as the corresponding test file might not be correctly found. 

The current options also do not work for languages where test files may have different extensions from source files (e.g. `.ex` vs `.exs` in elixir)

This PR adds three new options to address these issues
* `source_ext` (optional): used to specify a language's source file extension if it differs from its test file extension. This is optional and will default to the `ext` option.
* `source_path_prefix` (optional): prefix for where source files are stored. This option should be used if the source file structure mirrors the test file structure up to the prefix (e.g. `app/models/user.rb` and `spec/models/user_spec.rb`). Usage requires `test_path_prefix` option to be defined as well.
* `test_path_prefix` (optional): same as `source_path_prefix` but for test files.

If one of or both `source_path_prefix` an `test_path_prefix` are not defined, it defaults the search path for both source and test files to `.`. The `fd` search now uses the glob flag `-g` to search for the exact file name in the search directory.

Elixir has also been added as an included language.
